### PR TITLE
Avoid adding event listeners multiple times

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,40 @@
 import Oscillator from './src/nes/browser/oscillator.js';
 import Noise from './src/nes/browser/noise.js';
 
+let buf = null
+
+const convertKeyCode = (keyCode) => {
+  switch (keyCode) {
+  case 88: return 0x01; // X  A
+  case 90: return 0x02; // Z  B
+  case 65: return 0x04; // A  SELECT
+  case 83: return 0x08; // S  START
+  case 38: return 0x10; // ↑  ↑
+  case 40: return 0x20; // ↓  ↓
+  case 37: return 0x40; // ←  ←
+  case 39: return 0x80; // →  →
+  }
+};
+
+const onKeydown = (e) => {
+  if (buf != null)
+    buf[buf.length - 1] |= convertKeyCode(e.keyCode);
+}
+
+const onKeyup = (e) => {
+  if (buf != null)
+    buf[buf.length - 1] &= ~convertKeyCode(e.keyCode);
+}
+
+const setupKeyHandler = () => {
+  if (typeof window !== 'undefined') {
+    document.addEventListener('keydown', onKeydown);
+    document.addEventListener('keyup', onKeyup);
+  }
+};
+
+setupKeyHandler();
+
 const start = async (rom = './roms/falling.nes') => {
   const run = Module.cwrap('run', null, ['number', 'number']);
   const canvas = document.querySelector("canvas");
@@ -25,38 +59,9 @@ const start = async (rom = './roms/falling.nes') => {
   // Add key code area to tail.
   const size = nes.byteLength + 1;
   const ptr = Module._malloc(size);
-  const buf = new Uint8Array(Module.HEAPU8.buffer, ptr, size);
+  buf = new Uint8Array(Module.HEAPU8.buffer, ptr, size);
   buf.set(nes);
 
-  const convertKeyCode = (keyCode) => {
-    switch (keyCode) {
-      case 88: return 0x01; // X  A 
-      case 90: return 0x02; // Z  B
-      case 65: return 0x04; // A  SELECT
-      case 83: return 0x08; // S  START
-      case 38: return 0x10; // ↑  ↑  
-      case 40: return 0x20; // ↓  ↓
-      case 37: return 0x40; // ←  ←
-      case 39: return 0x80; // →  →
-    }
-  };
-
-  const onKeydown = (e) => {
-    buf[size - 1] |= convertKeyCode(e.keyCode);
-  }
-
-  const onKeyup = (e) => {
-    buf[size - 1] &= ~convertKeyCode(e.keyCode);
-  }
-
-  const setupKeyHandler = () => {
-    if (typeof window !== 'undefined') {
-      document.addEventListener('keydown', onKeydown);
-      document.addEventListener('keyup', onKeyup);
-    }
-  };
-
-  setupKeyHandler();
   console.log('start nes');
   run(size, buf.byteOffset);
 };


### PR DESCRIPTION
When a user select a rom type, `start` function is called.

In the function, event listeners for key event are added to `document` object,
so they are possibly added multiple times.

Also, old `buf` keeps alive because event listeners holds it.

This change moves `buf` from function local to module variable,
and adds event listeners to `document` only once.