### PR TITLE
Export 'cwrap' function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	cargo rustc --release \
 	--target=wasm32-unknown-emscripten -- \
     -C opt-level=3 \
-	-C link-args="-O3 -s NO_EXIT_RUNTIME=1 -s EXPORTED_FUNCTIONS=['_run']" \
+	-C link-args="-O3 -s NO_EXIT_RUNTIME=1 -s EXPORTED_FUNCTIONS=['_run'] -s EXTRA_EXPORTED_RUNTIME_METHODS=['cwrap']" \
 	--verbose   
 	cp target/wasm32-unknown-emscripten/release/rustynes.js wasm/rustynes.js
 	cp target/wasm32-unknown-emscripten/release/deps/*.wasm wasm/rustynes.wasm


### PR DESCRIPTION
I'm new to Rust and Emscripten,
so not fully understand the toolchain.

But in my environment, the generated code doesn't work.
I spent some amount of time, and found `cwrap` function needs to be exported.

Would you please look at the chage? Thanks!

Versions:

```
$ rustc --version
rustc 1.30.0-nightly (f8d34596f 2018-08-30)
$ emcc --version
emcc (Emscripten gcc/clang-like replacement) 1.38.11 (commit 0d8576c0e8f5ee09a36120b9d44184b5da2f2e7a)
Copyright (C) 2014 the Emscripten authors (see AUTHORS.txt)
This is free and open source software under the MIT license.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
