### PR TITLE
Handle vertical flip for 8x16 sprite properly

### DIFF
--- a/src/nes/ppu/sprite.rs
+++ b/src/nes/ppu/sprite.rs
@@ -43,7 +43,7 @@ pub fn build_sprites<P: PaletteRam>(
                 (offset, sprite_id)
             };
             let x = sprite_ram.read(base + 3);
-            let sprite = build(&cram, sprite_id as u8, offset, &mmc);
+            let sprite = build(&cram, sprite_id as u8, offset, &mmc, is_8x8);
             let position: SpritePosition = (x, y - 8);
             let palette_id = attr & 0x03;
             buf.push(SpriteWithCtx {
@@ -52,17 +52,6 @@ pub fn build_sprites<P: PaletteRam>(
                 attr,
                 palette: palette.get(palette_id, PaletteType::Sprite),
             });
-            if !is_8x8 {
-                let sprite = build(&cram, sprite_id + 1 as u8, offset, &mmc);
-                let position: SpritePosition = (x, y);
-                let palette_id = attr & 0x03;
-                buf.push(SpriteWithCtx {
-                    sprite,
-                    position,
-                    attr,
-                    palette: palette.get(palette_id, PaletteType::Sprite),
-                });
-            }
         }
     }
     buf

--- a/src/nes/ppu/sprite_utils.rs
+++ b/src/nes/ppu/sprite_utils.rs
@@ -43,14 +43,17 @@ pub fn get_attribute(vram: &Ram, position: &SpritePosition, config: &SpriteConfi
     vram.read(mirror_down_sprite_addr(addr, config.is_horizontal_mirror))
 }
 
-pub fn build(cram: &Ram, sprite_id: u8, offset: u16, mmc: &Mmc) -> Sprite {
-    let mut sprite: Sprite = (0..8).into_iter().map(|_| vec![0; 8]).collect();
-    for i in 0..16 {
-        for j in 0..8 {
-            let addr = (sprite_id as u16) * 16 + i + offset;
-            let ram = cram.read(mmc.create_chram_addr(addr));
-            if ram & (0x80 >> j) as u8 != 0 {
-                sprite[(i % 8) as usize][j] += (0x01 << (i / 8)) as u8;
+pub fn build(cram: &Ram, sprite_id: u8, offset: u16, mmc: &Mmc, is_8x8: bool) -> Sprite {
+    let h = if is_8x8 { 1 } else { 2 };
+    let mut sprite: Sprite = (0..8 * h).into_iter().map(|_| vec![0; 8 * h]).collect();
+    for k in 0..h {
+        for i in 0..16 {
+            for j in 0..8 {
+                let addr = ((sprite_id + (k as u8)) as u16) * 16 + i + offset;
+                let ram = cram.read(mmc.create_chram_addr(addr));
+                if ram & (0x80 >> j) as u8 != 0 {
+                    sprite[((k as u16) * 8 + i % 8) as usize][j] += (0x01 << (i / 8)) as u8;
+                }
             }
         }
     }

--- a/src/nes/ppu/tile.rs
+++ b/src/nes/ppu/tile.rs
@@ -28,6 +28,7 @@ impl Tile {
             sprite_id,
             config.offset_addr_by_background_table,
             &mmc,
+            true,
         );
         Tile {
             sprite,

--- a/src/nes/renderer/mod.rs
+++ b/src/nes/renderer/mod.rs
@@ -66,10 +66,11 @@ impl Renderer {
         let is_vertical_reverse = (attr & 0x80) == 0x80;
         let is_horizontal_reverse = (attr & 0x40) == 0x40;
         let is_low_priority = (attr & 0x20) == 0x20;
-        for i in 0..8 {
+        let h = sprite.len();
+        for i in 0..h {
             for j in 0..8 {
                 let x = position.0 as usize + if is_horizontal_reverse { 7 - j } else { j };
-                let y = position.1 as usize + if is_vertical_reverse { 7 - i } else { i };
+                let y = position.1 as usize + if is_vertical_reverse { h - 1 - i } else { i };
                 if is_low_priority && self.should_pixel_hide(x, y, background) {
                     continue;
                 }


### PR DESCRIPTION
Vertical flip for 8x16 sprite flips 16 dots,
not two 8 dots.

To achieve this, handle 8x16 sprite as one sprite,
and flip vertically properly.

I've confirmed the behavior on "Gradius".
