### PR TITLE
Add standalone version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,10 @@ dependencies = [
  "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "standalone"
+version = "0.1.0"
+
 [metadata]
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)" = "2370ca07ec338939e356443dac2296f581453c35fe1e3a3ed06023c49435f915"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,9 @@ dependencies = [
 [[package]]
 name = "standalone"
 version = "0.1.0"
+dependencies = [
+ "rustynes 0.1.0",
+]
 
 [metadata]
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,12 +1,186 @@
 [[package]]
+name = "autocfg"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lazy_static"
 version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
 version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustynes"
@@ -17,12 +191,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "sdl2"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sdl2-sys 0.32.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sdl2-sys"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "standalone"
 version = "0.1.0"
 dependencies = [
  "rustynes 0.1.0",
+ "sdl2 0.32.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
+[[package]]
+name = "winapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
+"checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
+"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
+"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)" = "2370ca07ec338939e356443dac2296f581453c35fe1e3a3ed06023c49435f915"
+"checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
+"checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
+"checksum num-iter 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "76bd5272412d173d6bf9afdf98db8612bbabc9a7a830b7bfc9c188911716132e"
+"checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
+"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
+"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+"checksum rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+"checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+"checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+"checksum sdl2 0.32.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d051a07231e303f5f719da78cb6f7394f6d5b54f733aef5b0b447804a83edd7b"
+"checksum sdl2-sys 0.32.6 (registry+https://github.com/rust-lang/crates.io-index)" = "34e71125077d297d57e4c1acfe8981b5bdfbf5a20e7b589abfdcb33bf1127f86"
+"checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,8 @@ authors = ["bokuweb <bokuweb12@gmail.com>"]
 
 libc="*"
 lazy_static="0.2.8"
+
+[workspace]
+members = [
+    "standalone",
+]

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,22 @@
+.PHONY: build clean standalone
+
 build:
 	mkdir -p wasm
 	rm -rf target/wasm32-unknown-emscripten/release/deps/*.wasm
 	rm -rf target/wasm32-unknown-emscripten/release/rustynes.js
-	cargo rustc --release \
+	cargo rustc --release --bin rustynes \
 	--target=wasm32-unknown-emscripten -- \
     -C opt-level=3 \
 	-C link-args="-O3 -s NO_EXIT_RUNTIME=1 -s EXPORTED_FUNCTIONS=['_run'] -s EXTRA_EXPORTED_RUNTIME_METHODS=['cwrap']" \
-	--verbose   
+	--verbose
 	cp target/wasm32-unknown-emscripten/release/rustynes.js wasm/rustynes.js
 	cp target/wasm32-unknown-emscripten/release/deps/*.wasm wasm/rustynes.wasm
 	wasm-gc wasm/rustynes.wasm wasm/rustynes.wasm
 
 clean:
 	rm -rf target/wasm32-unknown-emscripten/release/deps/*.wasm
-	rm -rf target/wasm32-unknown-emscripten/release/rustynes.js  
+	rm -rf target/wasm32-unknown-emscripten/release/rustynes.js
+	rm -rf target/release
+
+standalone:
+	cargo rustc -p standalone --release

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+#[macro_use]
+extern crate lazy_static;
+
+pub mod nes;

--- a/src/nes/mod.rs
+++ b/src/nes/mod.rs
@@ -86,6 +86,10 @@ pub fn run(ctx: &mut Context, key_state: u8) {
     }
 }
 
+pub fn get_render_buf(ctx: &mut Context) -> &Vec<u8> {
+    ctx.renderer.get_buf()
+}
+
 impl Context {
     pub fn new(buf: &mut [Data]) -> Self {
         let cassette = parser::parse(buf);

--- a/src/nes/renderer/mod.rs
+++ b/src/nes/renderer/mod.rs
@@ -28,6 +28,10 @@ impl Renderer {
         }
     }
 
+    pub fn get_buf(&self) -> &Vec<u8> {
+        &self.buf
+    }
+
     fn should_pixel_hide(&self, x: usize, y: usize, background: &BackgroundField) -> bool {
         let tile_x = x / 8;
         let tile_y = y / 8;

--- a/standalone/Cargo.toml
+++ b/standalone/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["tyfkda <tyfkda@gmail.com>"]
 
 [dependencies]
+sdl2 = "0.32.2"
 rustynes = { path = ".." }
 
 [[bin]]

--- a/standalone/Cargo.toml
+++ b/standalone/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "standalone"
+version = "0.1.0"
+authors = ["tyfkda <tyfkda@gmail.com>"]

--- a/standalone/Cargo.toml
+++ b/standalone/Cargo.toml
@@ -2,3 +2,10 @@
 name = "standalone"
 version = "0.1.0"
 authors = ["tyfkda <tyfkda@gmail.com>"]
+
+[dependencies]
+rustynes = { path = ".." }
+
+[[bin]]
+name = "rustynes"
+path = "src/main.rs"

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello!");
+}

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -6,6 +6,7 @@ use sdl2::event::{Event};
 use sdl2::keyboard::{Keycode};
 use sdl2::pixels::{Color};
 use sdl2::render::{WindowCanvas};
+use sdl2::rect::{Point};
 
 use std::time::{Duration};
 
@@ -48,7 +49,6 @@ impl App {
 
     pub fn run(&mut self) {
         let mut event_pump = self.sdl_context.event_pump().unwrap();
-        let mut i = 0;
         'running: loop {
             for event in event_pump.poll_iter() {
                 match event {
@@ -61,11 +61,7 @@ impl App {
             }
 
             self.update();
-
-            i = (i + 1) % 255;
-            self.canvas.set_draw_color(Color::RGB(i, 64, 255 - i));
-            self.canvas.clear();
-
+            self.render();
             self.canvas.present();
             ::std::thread::sleep(Duration::new(0, 1_000_000_000u32 / 60));
         }
@@ -77,6 +73,25 @@ impl App {
             Some(ctx) => {
                 let key_state = 0;
                 nes::run(ctx, key_state);
+            },
+            None => (),
+        }
+    }
+
+    fn render(&mut self) {
+        match &mut self.ctx {
+            Some(ctx) => {
+                let buf = nes::get_render_buf(ctx);
+                for i in 0..HEIGHT {
+                    for j in 0..WIDTH {
+                        let base = ((i * WIDTH + j) * 4) as usize;
+                        let r = buf[base + 0];
+                        let g = buf[base + 1];
+                        let b = buf[base + 2];
+                        self.canvas.set_draw_color(Color::RGB(r, g, b));
+                        let _ = self.canvas.draw_point(Point::new(j as i32, i as i32));
+                    }
+                }
             },
             None => (),
         }

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -1,7 +1,17 @@
 extern crate rustynes;
 
+use std::fs;
 use rustynes::nes;
+use rustynes::nes::Context;
 
 fn main() {
-    println!("Hello!");
+    match fs::read("roms/falling.nes") {
+        Result::Ok(mut rom) => {
+            let mut ctx = Context::new(&mut rom);
+            nes::reset(&mut ctx);
+        },
+        Result::Err(err) => {
+            panic!(err);
+        }
+    }
 }

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -1,3 +1,7 @@
+extern crate rustynes;
+
+use rustynes::nes;
+
 fn main() {
     println!("Hello!");
 }

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -10,6 +10,7 @@ use sdl2::rect::{Point};
 
 use std::time::{Duration};
 
+use std::env;
 use std::fs;
 use rustynes::nes;
 use rustynes::nes::Context;
@@ -159,14 +160,22 @@ fn start_noise() {}
 //fn close_noise();
 
 fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("<.nes file> required");
+        std::process::exit(1);
+    }
+
     let mut app = App::new();
 
-    match fs::read("roms/falling.nes") {
+    let filename = &args[1];
+    match fs::read(filename) {
         Result::Ok(rom) => {
             app.set_rom(rom);
             app.run();
         },
         Result::Err(err) => {
+            eprintln!("Cannot open .nes file: {}", filename);
             panic!(err);
         }
     }

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -1,12 +1,91 @@
 extern crate rustynes;
+extern crate sdl2;
+
+use sdl2::{Sdl};
+use sdl2::event::{Event};
+use sdl2::keyboard::{Keycode};
+use sdl2::pixels::{Color};
+use sdl2::render::{WindowCanvas};
+
+use std::time::{Duration};
 
 use std::fs;
 use rustynes::nes;
 use rustynes::nes::Context;
 
+const WIDTH: u32 = 256;
+const HEIGHT: u32 = 224;
+
+pub struct App {
+    sdl_context: Sdl,
+    canvas: WindowCanvas,
+
+    ctx: Option<Context>,
+}
+
+impl App {
+    pub fn new() -> App {
+        let sdl_context = sdl2::init().unwrap();
+        let video_subsystem = sdl_context.video().unwrap();
+        let window = video_subsystem.window("rustynes", WIDTH, HEIGHT)
+            .position_centered()
+            .build()
+            .unwrap();
+        let canvas = window.into_canvas().build().unwrap();
+
+        App {
+            sdl_context,
+            canvas,
+            ctx: None,
+        }
+    }
+
+    pub fn set_rom(&mut self, mut rom: Vec<u8>) {
+        let mut ctx = Context::new(&mut rom);
+        nes::reset(&mut ctx);
+        self.ctx = Some(ctx);
+    }
+
+    pub fn run(&mut self) {
+        let mut event_pump = self.sdl_context.event_pump().unwrap();
+        let mut i = 0;
+        'running: loop {
+            for event in event_pump.poll_iter() {
+                match event {
+                    Event::Quit {..} |
+                    Event::KeyDown { keycode: Some(Keycode::Escape), .. } => {
+                        break 'running
+                    },
+                    _ => {}
+                }
+            }
+
+            self.update();
+
+            i = (i + 1) % 255;
+            self.canvas.set_draw_color(Color::RGB(i, 64, 255 - i));
+            self.canvas.clear();
+
+            self.canvas.present();
+            ::std::thread::sleep(Duration::new(0, 1_000_000_000u32 / 60));
+        }
+    }
+
+    fn update(&mut self) {
+        let optctx = &mut self.ctx;
+        match optctx {
+            Some(ctx) => {
+                let key_state = 0;
+                nes::run(ctx, key_state);
+            },
+            None => (),
+        }
+    }
+}
+
 #[no_mangle]
-fn canvas_render(_ptr: *const u8, len: usize) {
-    println!("canvas_render, len={}", len);
+fn canvas_render(_ptr: *const u8, _len: usize) {
+    //println!("canvas_render, len={}", len);
 }
 
 #[no_mangle]
@@ -36,15 +115,12 @@ fn start_noise() {}
 //fn close_noise();
 
 fn main() {
-    match fs::read("roms/falling.nes") {
-        Result::Ok(mut rom) => {
-            let mut ctx = Context::new(&mut rom);
-            nes::reset(&mut ctx);
+    let mut app = App::new();
 
-            for _i in 0..10 {
-                let key_state = 0;
-                nes::run(&mut ctx, key_state);
-            }
+    match fs::read("roms/falling.nes") {
+        Result::Ok(rom) => {
+            app.set_rom(rom);
+            app.run();
         },
         Result::Err(err) => {
             panic!(err);

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -8,7 +8,7 @@ use sdl2::pixels::{Color};
 use sdl2::render::{WindowCanvas};
 use sdl2::rect::{Point};
 
-use std::time::{Duration};
+use std::time::{Duration, SystemTime};
 
 use std::env;
 use std::fs;
@@ -74,6 +74,7 @@ impl App {
     pub fn run(&mut self) {
         let mut event_pump = self.sdl_context.event_pump().unwrap();
         let mut pad = 0;
+        let mut prev_time = SystemTime::now();
         'running: loop {
             for event in event_pump.poll_iter() {
                 match event {
@@ -94,7 +95,12 @@ impl App {
             self.update(pad);
             self.render();
             self.canvas.present();
-            ::std::thread::sleep(Duration::new(0, 1_000_000_000u32 / 60));
+
+            let elapsed_time = SystemTime::now().duration_since(prev_time).expect("Time went backwards").as_nanos();
+            let wait = if elapsed_time < 1_000_000_000u128 / 60 { 1_000_000_000u32 / 60 - (elapsed_time as u32) } else { 0 };
+            ::std::thread::sleep(Duration::new(0, wait));
+
+            prev_time = SystemTime::now();
         }
     }
 

--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -4,11 +4,47 @@ use std::fs;
 use rustynes::nes;
 use rustynes::nes::Context;
 
+#[no_mangle]
+fn canvas_render(_ptr: *const u8, len: usize) {
+    println!("canvas_render, len={}", len);
+}
+
+#[no_mangle]
+fn start_oscillator(_index: usize) {}
+#[no_mangle]
+fn stop_oscillator(_index: usize) {}
+//#[no_mangle]
+// fn close_oscillator(index: usize) {}
+#[no_mangle]
+fn set_oscillator_frequency(_index: usize, _freq: usize) {}
+#[no_mangle]
+fn change_oscillator_frequency(_index: usize, _freq: usize) {}
+#[no_mangle]
+fn set_oscillator_volume(_index: usize, _volume: f32) {}
+#[no_mangle]
+fn set_oscillator_pulse_width(_index: usize, _width: f32) {}
+
+#[no_mangle]
+fn set_noise_frequency(_freq: f32) {}
+#[no_mangle]
+fn set_noise_volume(_volume: f32) {}
+#[no_mangle]
+fn stop_noise() {}
+#[no_mangle]
+fn start_noise() {}
+//#[no_mangle]
+//fn close_noise();
+
 fn main() {
     match fs::read("roms/falling.nes") {
         Result::Ok(mut rom) => {
             let mut ctx = Context::new(&mut rom);
             nes::reset(&mut ctx);
+
+            for _i in 0..10 {
+                let key_state = 0;
+                nes::run(&mut ctx, key_state);
+            }
         },
         Result::Err(err) => {
             panic!(err);


### PR DESCRIPTION
Running on a browser is great for publish,
but I think it would be great if Rustynes also runs as a standalone application.

In this changes, I have added `standalone` workspace.
Wasm version can be built as-is.

Build:

```sh
$ make standalone
```

Run:

```sh
$ cargo run -p standalone --release roms/hello.nes
```

I uses SDL2 to show graphics.

Currently, audio haven't implemented.
